### PR TITLE
task_loop.process: Modifiable path variable

### DIFF
--- a/src/yosys_mau/task_loop/process.py
+++ b/src/yosys_mau/task_loop/process.py
@@ -148,12 +148,14 @@ class Process(Task):
         *,
         cwd: os.PathLike[Any] | str | None = None,
         interact: bool = False,
+        path: str | None = None
     ):
         super().__init__()
         self.use_lease = True
         self.name = command[0]
         self.command = command
         self.interact = interact
+        self.pathvar = path
 
         self.__monitor_pipe = None
         self.__startup_buffer = []
@@ -191,6 +193,9 @@ class Process(Task):
     async def on_run(self) -> None:
         # TODO check what to do on Windows
         subprocess_args = job.global_client().subprocess_args()
+        if self.pathvar:
+            log(f"replacing PATH variable")
+            subprocess_args["env"]["PATH"] = self.pathvar
         wrapper = []
 
         cwd = ProcessContext.cwd

--- a/src/yosys_mau/task_loop/process.py
+++ b/src/yosys_mau/task_loop/process.py
@@ -194,7 +194,6 @@ class Process(Task):
         # TODO check what to do on Windows
         subprocess_args = job.global_client().subprocess_args()
         if self.pathvar:
-            log(f"replacing PATH variable")
             subprocess_args["env"]["PATH"] = self.pathvar
         wrapper = []
 

--- a/src/yosys_mau/task_loop/process.py
+++ b/src/yosys_mau/task_loop/process.py
@@ -148,7 +148,7 @@ class Process(Task):
         *,
         cwd: os.PathLike[Any] | str | None = None,
         interact: bool = False,
-        path: str | None = None
+        path: str | None = None,
     ):
         super().__init__()
         self.use_lease = True


### PR DESCRIPTION
Overrides `subprocess_args["env"]["PATH"]` in `on_run`.

Useful for doing things like configuring a subprocess to use a different
version of python than the current version (i.e. the one running mau).